### PR TITLE
chore: disable dockerhub image attestation

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -66,13 +66,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Attest dockerhub image
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
-        with:
-          subject-digest: ${{steps.build-and-push.outputs.digest}}
-          subject-name: index.docker.io/${{ github.repository }}
-          push-to-registry: true
-
       - name: Attest ghcr image
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:


### PR DESCRIPTION
Until dockerhub supports the OCI Referrers API, attestations attached to
images result in numerous noisy sha256-* tags. So disable dockerhub
image attestation for now.
